### PR TITLE
2.7: build without openssl/conf_api.h

### DIFF
--- a/2.7/Makefile
+++ b/2.7/Makefile
@@ -1,6 +1,6 @@
 VERSION =		2.7.8
 NEXTVER =		2.8
-REVISION =		2
+REVISION =		3
 
 SHARED_LIBS =		ruby${BINREV}	0.0
 

--- a/2.7/patches/patch-ext_openssl_ossl_h
+++ b/2.7/patches/patch-ext_openssl_ossl_h
@@ -1,0 +1,13 @@
+Index: ext/openssl/ossl.h
+--- ext/openssl/ossl.h.orig
++++ ext/openssl/ossl.h
+@@ -27,7 +27,9 @@
+ #include <openssl/hmac.h>
+ #include <openssl/rand.h>
+ #include <openssl/conf.h>
++#ifndef __OpenBSD__
+ #include <openssl/conf_api.h>
++#endif
+ #include <openssl/crypto.h>
+ #if !defined(OPENSSL_NO_ENGINE)
+ #  include <openssl/engine.h>


### PR DESCRIPTION
#2 